### PR TITLE
Fix for GitHub Extension loading error

### DIFF
--- a/Assets/Plugins/GitHub/Editor/ExtensionLoader.cs
+++ b/Assets/Plugins/GitHub/Editor/ExtensionLoader.cs
@@ -54,7 +54,13 @@ namespace GitHub.Unity
                 inSourceMode = File.Exists(scriptPath);
                 ToggleAssemblies();
                 //ExtensionLoader.instance.Initialized = true;
-                AssetDatabase.SaveAssets();
+
+                // HACK: Band-aid fix to prevent saving null paths
+                // scriptPath has incorrect slashes
+                if(inSourceMode)
+                {
+                    AssetDatabase.SaveAssets();
+                }
             }
 
         }

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-midnight


### PR DESCRIPTION
Might be a bandaid
Prevents GitHub extension from loading bad filepaths

Real problem is filePath has mismatched slashes "D:\AMS\...\folder//folder2//file.ext"